### PR TITLE
CMake: better CLP finder

### DIFF
--- a/cmake/FindCLP.cmake
+++ b/cmake/FindCLP.cmake
@@ -10,7 +10,6 @@ endif()
 find_path(CLP_INCLUDE_DIR
           NAMES ClpConfig.h
           PATHS "$ENV{CLP_DIR}/include/coin"
-                "$ENV{CBC_DIR}/include/coin"
                 "/opt/homebrew/include/clp/coin"  #homebrew default path
                 "/usr/local/include/clp/coin"     #homebrew default path
                 "/usr/include/coin"

--- a/cmake/FindCLP.cmake
+++ b/cmake/FindCLP.cmake
@@ -1,47 +1,49 @@
-# - Try to find CLP
-# Once done this will define
-#  CLP_FOUND - System has CLP
-#  CLP_INCLUDE_DIRS - The CLP include directories
-#  CLP_LIBRARIES - The libraries needed to use CLP
+# Try to find CLP: https://www.coin-or.org/Clp/
+# On success, this will define the target Coin::CLP
 
-if (CLP_INCLUDE_DIR)
-  # in cache already
-  set(CLP_FOUND TRUE)
-  set(CLP_INCLUDE_DIRS "${CLP_INCLUDE_DIR}" )
-  set(CLP_LIBRARIES "${CLP_LIBRARY}" )
-else (CLP_INCLUDE_DIR)
-
+if(NOT TARGET Coin::CLP)
+    if (NOT TARGET Coin::CoinUtils)
+        find_package(CoinUtils REQUIRED)
+    endif()
+endif()
 
 find_path(CLP_INCLUDE_DIR
           NAMES ClpConfig.h
           PATHS "$ENV{CLP_DIR}/include/coin"
-                 "/usr/include/coin"
-                 "/usr/include/coin-or"
-                 "/usr/local/include/coin-or"
+                "$ENV{CBC_DIR}/include/coin"
+                "/opt/homebrew/include/clp/coin"  #homebrew default path
+                "/usr/local/include/clp/coin"     #homebrew default path
+                "/usr/include/coin"
                  "C:\\libs\\clp\\include"
-          )
+                 "C:\\libs\\cbc\\include"
+                 "${VS_SEARCH_PATH}CBC-2.9.7/Clp/include"
+                 "${VS_SEARCH_PATH}CBC-2.9.4/Clp/include"
+              )
 
 find_library( CLP_LIBRARY
               NAMES Clp libClp
               PATHS "$ENV{CLP_DIR}/lib"
+                    "/opt/homebrew/lib"  # homebrew default path
+                    "/usr/local/lib"     # homebrew default path
                     "/usr/lib"
                     "/usr/lib/coin"
-                    "/usr/local/lib/coin-or"
-                    "/usr/local/lib"
                     "C:\\libs\\clp\\lib"
+                    "C:\\libs\\cbc\\lib"
               )
-
 
 set(CLP_INCLUDE_DIRS "${CLP_INCLUDE_DIR}" )
 set(CLP_LIBRARIES "${CLP_LIBRARY}" )
 
-
 include(FindPackageHandleStandardArgs)
-# handle the QUIETLY and REQUIRED arguments and set CLP_FOUND to TRUE
-# if all listed variables are TRUE
 find_package_handle_standard_args(CLP  DEFAULT_MSG
                                   CLP_LIBRARY CLP_INCLUDE_DIR)
 
-mark_as_advanced(CLP_INCLUDE_DIR CLP_LIBRARY)
+if(CLP_FOUND)
+    add_library(Coin::CLP SHARED IMPORTED)
+    set_property(TARGET Coin::CLP PROPERTY IMPORTED_LOCATION ${CLP_LIBRARY})
+    target_include_directories(Coin::CLP INTERFACE ${CLP_INCLUDE_DIR})
+    target_link_libraries(Coin::CLP INTERFACE Coin::CoinUtils)
+endif()
 
-endif(CLP_INCLUDE_DIR)
+
+mark_as_advanced(CLP_INCLUDE_DIR CLP_LIBRARY)

--- a/cmake/FindCoinUtils.cmake
+++ b/cmake/FindCoinUtils.cmake
@@ -1,0 +1,36 @@
+# Try to find Coin-ORs CoinUtils: https://www.coin-or.org/
+# On success, this will define the target Coin::CoinUtils
+
+find_path(CoinUtils_INCLUDE_DIR
+            NAMES CoinPragma.hpp
+          PATHS "$ENV{CoinUtils_DIR}/include/coin"
+                "/opt/homebrew/include/coinutils/coin"  #homebrew default path
+                "/usr/local/include/coinutils/coin"     #homebrew default path
+                "/usr/include/coinutils"
+                 "C:\\libs\\coinutils\\include"
+              )
+
+find_library( CoinUtils_LIBRARY
+    NAMES CoinUtils
+              PATHS "$ENV{CoinUtils_DIR}/lib"
+                    "/opt/homebrew/lib"  # homebrew default path
+                    "/usr/local/lib"     # homebrew default path
+                    "/usr/lib"
+                    "/usr/lib/coin"
+                    "C:\\libs\\clp\\lib"
+              )
+
+set(CoinUtils_INCLUDE_DIRS "${CoinUtils_INCLUDE_DIR}" )
+set(CoinUtils_LIBRARIES "${CoinUtils_LIBRARY}" )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CoinUtils DEFAULT_MSG CoinUtils_LIBRARY CoinUtils_INCLUDE_DIR)
+
+if(CoinUtils_FOUND)
+    add_library(Coin::CoinUtils SHARED IMPORTED)
+    set_property(TARGET Coin::CoinUtils PROPERTY IMPORTED_LOCATION ${CoinUtils_LIBRARY})
+    target_include_directories(Coin::CoinUtils INTERFACE ${CoinUtils_INCLUDE_DIR})
+endif()
+
+
+mark_as_advanced(CoinUtils_INCLUDE_DIR CoinUtils_LIBRARY)

--- a/cmake/FindCoinUtils.cmake
+++ b/cmake/FindCoinUtils.cmake
@@ -7,6 +7,7 @@ find_path(CoinUtils_INCLUDE_DIR
                 "/opt/homebrew/include/coinutils/coin"  #homebrew default path
                 "/usr/local/include/coinutils/coin"     #homebrew default path
                 "/usr/include/coinutils"
+                "/usr/include/coin"
                  "C:\\libs\\coinutils\\include"
               )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,24 +10,32 @@ endif()
 list(APPEND QGP3D_LIB_LIST MC3D::MC3D)
 
 #gurobi
-find_package(Gurobi)
 
-if (Gurobi_FOUND)
+option(MC3D_USE_GUROBI ON "Use Gurobi as solver if available.")
+
+if (MC3D_USE_GUROBI)
+    find_package(Gurobi)
+endif()
+
+if (Gurobi_FOUND AND MC3D_USE_GUROBI)
   list(APPEND QGP3D_COMPILE_DEFINITIONS_PUB "QGP3D_WITH_GUROBI")
   list(APPEND QGP3D_LIB_LIST_PRV Gurobi::GurobiC)
   list(APPEND QGP3D_LIB_LIST_PRV Gurobi::GurobiCXX)
+    message("QGP3D: Compiling Gurobi based solver.")
 else()
+    message("QGP3D: Not using gurobi, looking for alternatives.")
   if (NOT TARGET Eigen3::Eigen)
     find_package(Eigen3 3.3 REQUIRED NO_MODULE)
   endif()
   find_package(CLP REQUIRED)
-  list(APPEND QGP3D_LIB_LIST_PRV ${CLP_LIBRARIES})
+  list(APPEND QGP3D_LIB_LIST_PRV Coin::CLP)
   find_package(CBC)
   find_package(BONMIN)
   if (NOT CBC_FOUND OR NOT BONMIN_FOUND)
     message("QGP3D: Compiling without IQP solver support, only heuristic solver")
     list(APPEND QGP3D_COMPILE_DEFINITIONS_PUB "QGP3D_WITHOUT_IQP")
   else()
+    message("QGP3D: Compiling Bonmin based solver.")
     list(APPEND QGP3D_LIB_LIST_PRV Eigen3::Eigen)
     list(APPEND QGP3D_LIB_LIST_PRV ${BONMIN_LIBRARIES})
     list(APPEND QGP3D_LIB_LIST_PRV ${CBC_LIBRARIES})
@@ -97,9 +105,6 @@ target_include_directories(QGP3D
 
 if (NOT Gurobi_FOUND)
   if (NOT CBC_FOUND OR NOT BONMIN_FOUND)
-    target_include_directories(QGP3D SYSTEM
-                              PRIVATE
-                              "$<BUILD_INTERFACE:${CLP_INCLUDE_DIRS}>")
   else()
     target_include_directories(QGP3D SYSTEM
                                PRIVATE


### PR DESCRIPTION
This is only tested on my MacOS machine.
Could you see if this works on your computers?

I found some pkg-config based finders in 
https://github.com/google/or-tools/blob/2c333f58a37d7c75d29a58fd772c9b3f94e2ca1c/cmake/FindClp.cmake

If they work on windows, they're superior and we should use them.
